### PR TITLE
Added auto-terminate on idle to the EMR cluster configuration

### DIFF
--- a/lib/emr-product-stack.ts
+++ b/lib/emr-product-stack.ts
@@ -98,6 +98,13 @@ export class EmrStack extends sc.ProductStack {
                 default: "emr-6.4.0",
                 allowedValues: ["emr-6.4.0"]
             },
+            {
+                name: "AutoTerminationIdleTimout",
+                type: "String",
+                description: "Specifies the amount of idle time in seconds after which the cluster automatically terminates. You can specify a minimum of 60 seconds and a maximum of 604800 seconds (seven days).",
+                default: "3600",
+                allowedPattern: ["(6[0-9]|[7-9][0-9]|[1-9][0-9]{2,4}|[1-5][0-9]{5}|60[0-3][0-9]{3}|604[0-7][0-9]{2}|604800)"] 
+            }
         ]
 
         const emrSecurityConfigurationName  = Fn.importValue(props.emrSecurityConfigurationNameExportName)
@@ -274,6 +281,9 @@ export class EmrStack extends sc.ProductStack {
             releaseLabel: cfnParamMap.get("EmrReleaseVersion")?.valueAsString || "",
             visibleToAllUsers: true,
             securityConfiguration: emrSecurityConfigurationName,
+            autoTerminationPolicy: {
+                idleTimeout: Number(cfnParamMap.get("AutoTerminationIdleTimout")?.valueAsString) || 3600,
+            },
             steps: [
                 {
                     actionOnFailure: "CONTINUE",


### PR DESCRIPTION
## Description of your changes

Added auto-termination on idle to the Amazon EMR cluster configuration. Default value is 1 hour. Data Scientist can either keep the default value or adopt based on need during EMR Cluster generation in Amazon SageMaker Studio. 
Prior to this change EMR clusters would need to be terminated manually as outlined in issue #14
The change is self-contained

### How to verify this change
Deploy the updated kit. Cluster configuration for the provided EMR Cluster template provides the configuration option for an auto terminate after idle time. Provided a value in the valid range or keep the default value. Idle cluster will be terminated automatically after the specified time period.

### Related issues, RFCs
#14 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** YES

## Checklist

- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation* (e.g. README.md)
- [x] My changes generate *no new warnings*

---
