### PR TITLE
Implement automated deployment option

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -3,6 +3,9 @@ name: Prepare Deployment
 on:
   workflow_dispatch:
     
+permissions:
+      id-token: write
+      contents: read
 
 jobs:
   build:
@@ -14,7 +17,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18.x
-        cache: 'npm'
     - run: npm install -g cdk-standalone-deployer
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -22,16 +24,16 @@ jobs:
         role-to-assume: ${{ secrets.DEPLOYMENT_ROLE }}
         aws-region: ${{ secrets.DEPLOYMENT_BUCKET_REGION }}
     - name: Generate ML deployment stack
-      run: >
-        cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }}
-          --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-ml.json
-          --stack-name "aik/sagemaker-emr" --install-command "npm install && npx tsc" --build-command "npm run build"
-          --deploy-command "npx cdk deploy 'aik/sagemaker-emr' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit"
+      run: |
+        cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }} \
+          --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-ml.json \
+          --stack-name "aik/sagemaker-emr" --install-command "npm install && npx tsc" --build-command "npm run build" \
+          --deploy-command "npx cdk deploy 'aik/sagemaker-emr' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit" \
           --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker
     - name: Generate inference deployment stack
-      run: >
-        cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }}
-          --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-inference.json
-          --stack-name "aik/filtering" --install-command "npm install && npx tsc" --build-command "npm run build"
-          --deploy-command "npx cdk deploy 'aik/filtering' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit"
+      run: |
+        cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }} \
+          --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-inference.json \
+          --stack-name "aik/filtering" --install-command "npm install && npx tsc" --build-command "npm run build" \
+          --deploy-command "npx cdk deploy 'aik/filtering' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit" \
           --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Node.js ${{ matrix.node-version }}
+    - name: Install Node.js
       uses: actions/setup-node@v3
       with:
         node-version: 18.x
@@ -21,13 +21,17 @@ jobs:
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_ROLE }}
         aws-region: ${{ secrets.DEPLOYMENT_BUCKET_REGION }}
-    - run: cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }} \
-      --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-ml.json \
-      --stack-name "aik/sagemaker-emr" --install-command "npm install && npx tsc" --build-command "npm run build" \
-      --deploy-command "npx cdk deploy 'aik/sagemaker-emr' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit" \
-      --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker
-    - run: cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }} \
-      --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-inference.json \
-      --stack-name "aik/filtering" --install-command "npm install && npx tsc" --build-command "npm run build" \
-      --deploy-command "npx cdk deploy 'aik/filtering' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit" \
-      --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker
+    - name: Generate ML deployment stack
+      run: >
+        cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }}
+          --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-ml.json
+          --stack-name "aik/sagemaker-emr" --install-command "npm install && npx tsc" --build-command "npm run build"
+          --deploy-command "npx cdk deploy 'aik/sagemaker-emr' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit"
+          --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker
+    - name: Generate inference deployment stack
+      run: >
+        cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }}
+          --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-inference.json
+          --stack-name "aik/filtering" --install-command "npm install && npx tsc" --build-command "npm run build"
+          --deploy-command "npx cdk deploy 'aik/filtering' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit"
+          --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,0 +1,33 @@
+name: Prepare Deployment
+
+on:
+  workflow_dispatch:
+    
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18.x
+        cache: 'npm'
+    - run: npm install -g cdk-standalone-deployer
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.DEPLOYMENT_ROLE }}
+        aws-region: ${{ secrets.DEPLOYMENT_BUCKET_REGION }}
+    - run: cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }} \
+      --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-ml.json \
+      --stack-name "aik/sagemaker-emr" --install-command "npm install && npx tsc" --build-command "npm run build" \
+      --deploy-command "npx cdk deploy 'aik/sagemaker-emr' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit" \
+      --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker
+    - run: cdk-standalone-deployer generate-link --github-repo-name ${{ github.repository }} \
+      --s3-bucket-name ${{ secrets.DEPLOYMENT_BUCKET }} --s3-bucket-region ${{ secrets.DEPLOYMENT_BUCKET_REGION }} --s3-key-prefix aws-rtb-kit-inference.json \
+      --stack-name "aik/filtering" --install-command "npm install && npx tsc" --build-command "npm run build" \
+      --deploy-command "npx cdk deploy 'aik/filtering' --require-approval never -c @aws-cdk/core:bootstrapQualifier=rtbkit" \
+      --destroy-command "npx cdk destroy 'aik/**' --force -c @aws-cdk/core:bootstrapQualifier=rtbkit" --cdk-qualifier rtbkit --enable-docker

--- a/README.md
+++ b/README.md
@@ -19,13 +19,18 @@ If you notice a defect, have questions, or need support with deployment, please 
 
 ## Prerequisites
 
-These are prerequisites to build and deploy this application:
+* No Amazon SageMaker Domain in your Account as the Kit installs a new domain. You can only have one domain per account and region.
+* [kaggle](https://www.kaggle.com/) a Kaggle account to download the example data set into the Kit
+
+If you want to build this solution on your local environment, you will need to install these prerequisites:
 
 * [Node.js](https://nodejs.org/en/) with version higher than 10.13.0 (Please note that version between 13.0.0 and 13.6.0 are not compatible too)
 * [CDK](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html#getting_started_prerequisites) with version higher than 2.5.0
 * [Docker](https://docs.docker.com/get-docker/) version 20
-* No Amazon SageMaker Domain in your Account as the Kit installs a new domain. You can only have one domain per account and region.
-* [kaggle](https://www.kaggle.com/) a Kaggle account to download the example data set into the Kit
+
+Alternatively, you can build this solution in the AWS Cloud. For that, you will only need:
+
+* an AWS Account with a granted permission to deploy CloudFormation stacks.
 
 ## Architecture
 
@@ -50,6 +55,51 @@ The trained model is showcased in a traffic filtering use case where a bidding s
 ![Bidding Application](assets/traffic-filtering-server-view.png)
 
 ## Deployment
+
+### Cloud-powered deployment
+
+You can deploy this Kit into your Account leveraging such services as AWS CloudFormation and AWS CodeBuild without needing to install the dependencies locally.
+Please note that additional charges will apply, as this approach involves [bootstrapping a separate CDK environment](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html), running a [CodeBuild build](https://aws.amazon.com/codebuild/pricing/), and executing multiple AWS Lambda functions.
+
+This Kit consists of two CDK stacks. You will deploy both in the same way, just providing different stack URLs. After deploying the first part, continue with running the Kit. When you will need to deploy the **inference part** of the Kit, refer back to this deployment guide again.
+
+#### Using AWS Management Console
+
+1. Navigate to the CloudFormation console.
+2. Choose **Create stack** - **Template is ready** - **Amazon S3 URL**.
+3. Enter the *Amazon S3 Url* of the stack you want to deploy:
+    * ML part: **TODO: URL HERE**
+    * Inference part: **TODO: URL HERE**
+4. Click **Next**.
+5. Enter the *Stack name*, for example, **RTB-Kit-Part1** or **RTB-Kit-Part2**. Keep the parameter **CDKQUALIFIER** with its default value.
+6. Clock **Next**.
+7. Add tags if desired and click **Next**.
+8. Scroll down to the bottom, check **I acknowledge that AWS CloudFormation might create IAM resources** and click **Submit**.
+9. Wait until the stack is successfully deployed. There will be several additional stacks created.
+
+After deploying the Kit, continue to [Run the solution](#run-the-solution). If you decided to build the Kit locally, continue with [Install](#install) instead.
+
+#### Using AWS CLI
+
+1. Make sure your AWS CLI credentials are configured for your AWS Account and the target region.
+2. Run the following command, changing the `--stack-name` argument if desired:
+    * ML part:
+
+    ```bash
+    aws cloudformation create-stack --template-url **TODO: URL HERE** \
+     --parameters ParameterKey=CDKQUALIFIER,ParameterValue=rtbkit \
+     --capabilities CAPABILITY_IAM --stack-name RTB-Kit-Part1 
+    ```
+
+    * Inference part:
+
+    ```bash
+    aws cloudformation create-stack --template-url **TODO: URL HERE** \
+     --parameters ParameterKey=CDKQUALIFIER,ParameterValue=rtbkit \
+     --capabilities CAPABILITY_IAM --stack-name RTB-Kit-Part2
+    ```
+
+After deploying the Kit, continue to [Run the solution](#run-the-solution). If you decided to build the Kit locally, continue with [Install](#install) instead.
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ After deploying the Kit, continue to [Run the solution](#run-the-solution). If y
     ```bash
     aws cloudformation create-stack --template-url **TODO: URL HERE** \
      --parameters ParameterKey=CDKQUALIFIER,ParameterValue=rtbkit \
-     --capabilities CAPABILITY_IAM --stack-name RTB-Kit-Part1 
+     --capabilities CAPABILITY_IAM --stack-name RTB-Kit-Part1
     ```
 
     * Inference part:
@@ -362,9 +362,18 @@ Follow these instructions to remove the Kit from your Account.
     3. Delete the SageMaker Studio Domain
     4. Delete the Elastic File System created by SageMaker
 3. Delete parameters from Parameter store
-4. Run the following commands:
+4. If you deployed the Kit from your local environment, run the following commands:
 
-```sh
-cdk destroy "aik/filtering"
-cdk destroy "aik/sagemaker-emr"
-```
+    ```sh
+    cdk destroy "aik/filtering"
+    cdk destroy "aik/sagemaker-emr"
+    ```
+
+5. If you deployed the Kit using the Cloud-powered approach, delete the CloudFormation stacks created.
+    * Delete the stacks using AWS Management Console
+    * Alternatively, use AWS CLI:
+
+    ```sh
+    aws cloud-formation delete-stack --stack-name RTB-Kit-Part1
+    aws cloud-formation delete-stack --stack-name RTB-Kit-Part2
+    ```


### PR DESCRIPTION
## Description of your changes

This PR adds a workflow that can be manually run to create CloudFormation stacks for standalone (automated) deployment of the Kit. The workflow stores the stacks on an S3 bucket, so that the stacks can be directly used by the customers to deploy the Kit via the CloudFormation console or AWS CLI.

### How to verify this change

- Configure the needed secrets in the repo:
  - `DEPLOYMENT_ROLE` - the ARN of a role that the GitHub action will assume, see
  - `DEPLOYMENT_BUCKET` - the name of the S3 bucket where the stacks will be stored, the IAM role mentioned above must have `PutObject` permissions for this bucket
  - `DEPLOYMENT_BUCKET_REGION` - the region name where the bucket resides
- Run the workflow
- Check that the CloudFormation stacks are generated and stored in the specified S3 bucket
- Deploy the stacks as described in the README file

### Related issues, RFCs

N/A

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation* (e.g. README.md)
- [x] My changes generate *no new warnings*

---
